### PR TITLE
Update python_version 3.13 phase 5

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/dnsdb.json
+++ b/dnsdb.json
@@ -16,7 +16,7 @@
             "name": "Farsight Security, Inc."
         }
     ],
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "latest_tested_versions": [
         "Cloud API, v2.0, 2023-04-10"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * chore(ci): update pre-commit config
 * Resolved app issues related to Python 3.13 upgrade
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 5 part 2

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase5-part2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase5-part2)